### PR TITLE
Compilation fix

### DIFF
--- a/Source/WebCore/bindings/js/JSNodeFilterCondition.cpp
+++ b/Source/WebCore/bindings/js/JSNodeFilterCondition.cpp
@@ -34,7 +34,7 @@ using namespace JSC;
 ASSERT_CLASS_FITS_IN_CELL(JSNodeFilterCondition);
 
 JSNodeFilterCondition::JSNodeFilterCondition(JSGlobalData&, NodeFilter* owner, JSValue filter)
-    : m_filter(filter.isObject() ? PassWeak<JSObject>(jsCast<JSObject*>(filter), &m_weakOwner, owner) : 0)
+    : m_filter(filter.isObject() ? PassWeak<JSObject>(jsCast<JSObject*>(filter), &m_weakOwner, owner) : nullptr)
 {
 }
 


### PR DESCRIPTION
Just using 0 for a null pointer in this position did not work using g++ 6.1.9 (it complains about type mismatch). Changing 0 to nullptr makes it work.